### PR TITLE
Fixed white background in extended visitor profile details card.

### DIFF
--- a/stylesheets/components/_visitor_profile.less
+++ b/stylesheets/components/_visitor_profile.less
@@ -40,3 +40,7 @@
     }
   }
 }
+
+.visitor-profile-visit-details-extended {
+  background-color: unset;
+}


### PR DESCRIPTION
When viewing a visitor profile card, extended details of a specific visit were displayed on light grey background which made white text almost unreadable (probably related to Issue #1).

Before:
![visitor_details_extended](https://user-images.githubusercontent.com/49032022/99299895-2f3bb600-284c-11eb-93e9-0cc1141845d8.jpg)

After:
![visitor_details_extended_fixed](https://user-images.githubusercontent.com/49032022/99299909-3367d380-284c-11eb-8dc7-3ab2cb1aefbc.jpg)

