### PR TITLE
Fix colors for Real-time visitor count widget

### DIFF
--- a/stylesheets/components/_visitor_live_count.less
+++ b/stylesheets/components/_visitor_live_count.less
@@ -1,0 +1,11 @@
+.simple-realtime-visitor-counter {
+	background-color: var(--darker);
+}
+
+.simple-realtime-visitor-counter > div {
+	color: var(--light);
+}
+
+.simple-realtime-elaboration, .simple-realtime-metric {
+	color: unset;
+}

--- a/stylesheets/theme.less
+++ b/stylesheets/theme.less
@@ -38,6 +38,7 @@
 @import "components/_tagmanager_debugbar";
 @import "components/_transitions";
 @import "components/_ui_menu";
+@import "components/_visitor_live_count";
 @import "components/_visitor_log";
 @import "components/_visitor_profile";
 @import "components/_visits_live";


### PR DESCRIPTION
The text on the "Real-time visitor count" dashboard widget is currently not very readable. This patch fixes it.

Before:
![before](https://github.com/ronan-hello/matomo-dark-theme/assets/15653942/b1c9a85d-b3a6-442c-a4a8-87c5ef8e1c1f)

After:
![after](https://github.com/ronan-hello/matomo-dark-theme/assets/15653942/f121e6d8-c893-4740-b0c9-7d5e32864385)
